### PR TITLE
Fix/bug 45 health status issue

### DIFF
--- a/apps/dashboard/src/components/modules/health-status/types/health.types.ts
+++ b/apps/dashboard/src/components/modules/health-status/types/health.types.ts
@@ -12,6 +12,7 @@ export interface HealthMetric {
 export interface PackageHealth {
   name: string;
   packageOverallScore: number;
+  overallScore?: number;
   buildStatus: 'success' | 'failed' | 'building' | 'unknown';
   testCoverage: number;
   lintStatus: 'pass' | 'warn' | 'fail';

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -20,7 +20,8 @@
     "db:url": "node dist/get-db-url.js",
     "generate": "tsx src/run-db.ts prisma generate",
     "migrate": "tsx src/run-db.ts prisma migrate dev",
-    "serve": "tsx src/run-db.ts node dist/cli.js --serve --root ../../"
+    "serve": "tsx src/run-db.ts node dist/cli.js --serve --root ../../",
+    "test": "vitest run"
   },
   "dependencies": {
     "@monodog/ci-status": "1.1.5",
@@ -51,6 +52,7 @@
     "cross-env": "^10.1.0",
     "ts-node": "^10.0.0",
     "tsx": "^4.6.0",
-    "typescript": "^5.3.8"
+    "typescript": "^5.3.8",
+    "vitest": "^4.1.4"
   }
 }

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -14,13 +14,6 @@ import { prisma } from './db/prisma';
 
 export { scanner } from './services/scan.service';
 
-export interface HealthMetric {
-  name: string;
-  value: number;
-  status: 'healthy' | 'warning' | 'error';
-  description: string;
-}
-
 // The main function exported and called by the CLI
 export function startServer(
   rootPath: string,

--- a/packages/backend/src/routes/health.routes.ts
+++ b/packages/backend/src/routes/health.routes.ts
@@ -9,7 +9,7 @@ import {
 const router = Router();
 
 router.get('/', getHealth);
-router.get('/refresh', refreshHealth);
+router.post('/refresh', refreshHealth);
 router.get('/packages', getAllPackagesHealth);
 router.get('/packages/:name', getPackageHealth);
 

--- a/packages/backend/src/services/health.service.ts
+++ b/packages/backend/src/services/health.service.ts
@@ -23,25 +23,39 @@ export const getSystemHealth = () => {
 export const getPackageHealthMetrics = async (name: string) => {
   const packages = scanMonorepo(process.cwd());
 
-  const packageInfo = packages.find(p => p.name === name);
+  const pkg = packages.find(p => p.name === name);
 
-  if (!packageInfo) {
+  if (!pkg) {
     throw new Error('Package not found');
   }
+
+  const buildStatus = await funCheckBuildStatus(pkg);
+  const testCoverage = await funCheckTestCoverage(pkg);
+  const lintStatus = await funCheckLintStatus(pkg);
+  const securityAudit = await funCheckSecurityAudit(pkg);
+
+  const overallScore = calculatePackageHealth(
+    buildStatus,
+    testCoverage,
+    lintStatus,
+    securityAudit
+  );
 
   return {
     packageName: name,
     health: {
-      buildStatus: 'success',
-      testCoverage: Math.floor(Math.random() * 100),
-      lintStatus: 'pass',
-      securityAudit: 'pass',
-      overallScore: Math.floor(Math.random() * 40) + 60,
+      buildStatus,
+      testCoverage,
+      lintStatus,
+      securityAudit,
+      overallScore: overallScore.overallScore,
       lastUpdated: new Date(),
     },
-    size: {
-      size: Math.floor(Math.random() * 1024 * 1024),
-      files: Math.floor(Math.random() * 1000),
+
+    dependencies: {
+      dependencies: pkg.dependencies || [],
+      devDependencies: pkg.devDependencies || [],
+      peerDependencies: pkg.peerDependencies || [],
     },
   };
 };

--- a/packages/backend/src/types/health.ts
+++ b/packages/backend/src/types/health.ts
@@ -9,3 +9,10 @@ export interface PackageHealth {
   securityAudit: 'pass' | 'fail' | 'unknown';
   overallScore: number;
 }
+
+export interface HealthMetric {
+  name: string;
+  value: number;
+  status: 'healthy' | 'warning' | 'error';
+  description: string;
+}

--- a/packages/backend/tests/controllers/health.controller.test.ts
+++ b/packages/backend/tests/controllers/health.controller.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  getHealth,
+  getPackageHealth,
+} from '../../src/controllers/health.controller';
+import * as healthService from '../../src/services/health.service';
+import { Request, Response } from 'express';
+
+vi.mock('../../src/services/health.service', () => ({
+  getSystemHealth: vi.fn(),
+  getPackageHealthMetrics: vi.fn(),
+  getAllPackagesHealthMetrics: vi.fn(),
+  refreshPackagesHealth: vi.fn(),
+}));
+
+describe('Health Controller', () => {
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  const jsonSpy = vi.fn();
+  const statusSpy = vi.fn().mockReturnThis();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequest = {};
+    mockResponse = {
+      json: jsonSpy,
+      status: statusSpy,
+    };
+  });
+
+  describe('getHealth', () => {
+    it('should return 200 and system health', () => {
+      const mockHealth = {
+        status: 'ok',
+        timestamp: 123,
+        version: '1.0.0',
+        services: {},
+      };
+      vi.mocked(healthService.getSystemHealth).mockReturnValue(
+        mockHealth as any
+      );
+
+      getHealth(mockRequest as Request, mockResponse as Response);
+
+      expect(jsonSpy).toHaveBeenCalledWith(mockHealth);
+    });
+
+    it('should return 500 if service throws', () => {
+      vi.mocked(healthService.getSystemHealth).mockImplementation(() => {
+        throw new Error('Service error');
+      });
+
+      getHealth(mockRequest as Request, mockResponse as Response);
+
+      expect(statusSpy).toHaveBeenCalledWith(500);
+      expect(jsonSpy).toHaveBeenCalledWith({
+        error: 'Failed to fetch health status',
+      });
+    });
+  });
+
+  describe('getPackageHealth', () => {
+    it('should return package health metrics', async () => {
+      mockRequest.params = { name: 'test-pkg' };
+      const mockMetrics = { packageName: 'test-pkg', health: {} };
+      vi.mocked(healthService.getPackageHealthMetrics).mockResolvedValue(
+        mockMetrics as any
+      );
+
+      await getPackageHealth(mockRequest as Request, mockResponse as Response);
+
+      expect(jsonSpy).toHaveBeenCalledWith(mockMetrics);
+    });
+
+    it('should return 404 if package not found', async () => {
+      mockRequest.params = { name: 'unknown' };
+      vi.mocked(healthService.getPackageHealthMetrics).mockRejectedValue(
+        new Error('Package not found')
+      );
+
+      await getPackageHealth(mockRequest as Request, mockResponse as Response);
+
+      expect(statusSpy).toHaveBeenCalledWith(404);
+      expect(jsonSpy).toHaveBeenCalledWith({ error: 'Package not found' });
+    });
+  });
+});

--- a/packages/backend/tests/services/health.service.test.ts
+++ b/packages/backend/tests/services/health.service.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  getSystemHealth,
+  getPackageHealthMetrics,
+} from '../../src/services/health.service';
+import * as utils from '@monodog/utils/helpers';
+import * as scanner from '@monodog/monorepo-scanner';
+
+vi.mock('../../src/db/prisma', () => ({
+  prisma: {
+    packageHealth: {
+      findMany: vi.fn(),
+      upsert: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('@monodog/utils/helpers', () => ({
+  scanMonorepo: vi.fn(),
+  calculatePackageHealth: vi.fn(),
+}));
+
+vi.mock('@monodog/monorepo-scanner', () => ({
+  funCheckBuildStatus: vi.fn(),
+  funCheckTestCoverage: vi.fn(),
+  funCheckLintStatus: vi.fn(),
+  funCheckSecurityAudit: vi.fn(),
+}));
+
+describe('Health Service', () => {
+  describe('getSystemHealth', () => {
+    it('should return system health status', () => {
+      const health = getSystemHealth();
+      expect(health.status).toBe('ok');
+      expect(health.services).toBeDefined();
+      expect(health.timestamp).toBeLessThanOrEqual(Date.now());
+    });
+  });
+
+  describe('getPackageHealthMetrics', () => {
+    it('should throw error if package not found', async () => {
+      vi.mocked(utils.scanMonorepo).mockReturnValue([]);
+
+      await expect(getPackageHealthMetrics('non-existent')).rejects.toThrow(
+        'Package not found'
+      );
+    });
+
+    it('should return metrics for a found package', async () => {
+      const mockPackage = {
+        name: 'test-pkg',
+        dependencies: [],
+        devDependencies: [],
+        peerDependencies: [],
+      };
+      vi.mocked(utils.scanMonorepo).mockReturnValue([mockPackage as any]);
+      vi.mocked(scanner.funCheckBuildStatus).mockResolvedValue('success');
+      vi.mocked(scanner.funCheckTestCoverage).mockResolvedValue(80);
+      vi.mocked(scanner.funCheckLintStatus).mockResolvedValue('pass');
+      vi.mocked(scanner.funCheckSecurityAudit).mockResolvedValue('pass');
+      vi.mocked(utils.calculatePackageHealth).mockReturnValue({
+        overallScore: 85,
+      } as any);
+
+      const metrics = await getPackageHealthMetrics('test-pkg');
+
+      expect(metrics.packageName).toBe('test-pkg');
+      expect(metrics.health.overallScore).toBe(85);
+      expect(metrics.health.buildStatus).toBe('success');
+    });
+  });
+});

--- a/packages/backend/vitest.config.ts
+++ b/packages/backend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    coverage: {
+      reporter: ['text', 'html'],
+    },
+  },
+});


### PR DESCRIPTION
# Pull Request Description

This pull request addresses the following issue:

**Feature**: [GitHub Issue #45 ](https://github.com/mindfiredigital/monodog/issues/45)

### Changes Made:

- Fixed getPackageHealthMetrics() logic for correctly returning package health in health.service.ts
- Fixed refresh route http method for refresh route in health.route.ts
- Added types and interface for health metrics to resolve vs code errors
- Added test cases for health endpoint


### Checklist:

- [x] [Specific task related to the feature]
- [x] [Another specific task]
- [x] Ensure all components are properly typed with TypeScript.
- [x] Add or update unit tests for new functionality.
- [x] Update documentation (comments, README, etc.) to reflect changes.
- [x] The file(s) or folder(s) now contain changes as specified in the issue I worked on.
- [x] Check build, test, lint and format by run running command `pnpm run build` at root directory.
- [x] I certify that I ran the checklist.

### Testing:

- /health/packages and /health/refresh API endpoint's work correctly
- All test cases passes


## Closing

Closes #45 
